### PR TITLE
Workflow page added

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,9 @@ plugins:
   - multirepo:
 nav:
   - Home: 'index.md'
-  - For the developer: 'getting-started-developer.md'
+  - For the developer:
+    - Getting Started: 'getting-started-developer.md'
+    - Workflows: '!import https://github.com/eclipse-opensmartclide/kie-wb-common?branch=SmartCLIDE-addons'
   - For the sysadmin: 'getting-started-sysadmin.md'
   
 


### PR DESCRIPTION
The workflow page was added inside the "For the developer" section.

The new page is basically the mkdocs of the [jBPM repo](https://github.com/eclipse-opensmartclide/kie-wb-common/tree/SmartCLIDE-addons)

This page contains:
- The basic workflow functionalities of jBPM
- The SmartCLIDE additions
- Examples for two use cases